### PR TITLE
Dependabot: Keep GitHub Actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,11 @@ updates:
       interval: "daily"
       time: "13:00"
     open-pull-requests-limit: 1
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
+    schedule:
+      interval: weekly


### PR DESCRIPTION
The `patterns` approach means that there will never be more than one GHA upgrade PR.
The `weekly` schedule is because GHA's are infrequently updated.
* https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
* https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem